### PR TITLE
fix: libsql ERR_INVALID_URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.0.18",
-    "@libsql/client": "^0.6.0",
+    "@libsql/client": "0.5.6",
     "@prisma/adapter-libsql": "^5.13.0",
     "@prisma/client": "^5.13.0",
     "next": "^13.5.4",


### PR DESCRIPTION
the error existed due to a libsql+prisma+vercel [compatibility bug](https://github.com/prisma/prisma/issues/23774) in the libsql/client version and was resolved with a downgrade